### PR TITLE
Add ESXi host name to vm_data

### DIFF
--- a/custom_components/esxi_stats/esxi.py
+++ b/custom_components/esxi_stats/esxi.py
@@ -266,6 +266,7 @@ def get_vm_info(vm):
         "guest_os": vm_guest_os,
         "guest_ip": vm_ip,
         "snapshots": vm_snapshots,
+        "host_name": vm_run.host.name,
     }
 
     _LOGGER.debug(vm_data)


### PR DESCRIPTION
Added the ESXi host name(host_name) to vm_data so if you are getting your data from vCenter you will know what host the vm is on.  Please note, this is the first time doing this.  I hope I am doing this correctly.