### PR TITLE
Added VM's proper name and the host it runs on

### DIFF
--- a/custom_components/esxi_stats/const.py
+++ b/custom_components/esxi_stats/const.py
@@ -75,7 +75,8 @@ VM_STATES = [
     "status",
     "state",
     "uptime_hours",
-    "used_space_gb"
+    "used_space_gb",
+    "host_name"
 ]
 
 MAP_TO_MEASUREMENT = {

--- a/custom_components/esxi_stats/const.py
+++ b/custom_components/esxi_stats/const.py
@@ -76,7 +76,8 @@ VM_STATES = [
     "state",
     "uptime_hours",
     "used_space_gb",
-    "host_name"
+    "host_name",
+    "vm_name"
 ]
 
 MAP_TO_MEASUREMENT = {

--- a/custom_components/esxi_stats/esxi.py
+++ b/custom_components/esxi_stats/esxi.py
@@ -245,12 +245,20 @@ def get_vm_info(vm):
                 ("Unable to return Guest OS Name, using Configured Guest Name instead")
             )
             vm_guest_os = vm_sum.config.guestFullName
+            
+        if vm_sum.runtime.host.name:
+            vm_host_name = vm_sum.runtime.host.name
+        else:
+            vm_host_name = "n/a"
+            _LOGGER.debug("Unable to return Host Name for %s", vm_name)
+          
     else:
         vm_cpu_usage = "n/a"
         vm_mem_usage = "n/a"
         vm_ip = "n/a"
         vm_uptime = "n/a"
         vm_guest_os = vm_sum.config.guestFullName
+        vm_host_name = "n/a"
 
     vm_data = {
         "name": vm_name,
@@ -266,6 +274,7 @@ def get_vm_info(vm):
         "guest_os": vm_guest_os,
         "guest_ip": vm_ip,
         "snapshots": vm_snapshots,
+        "host_name": vm_host_name,
     }
 
     _LOGGER.debug(vm_data)

--- a/custom_components/esxi_stats/esxi.py
+++ b/custom_components/esxi_stats/esxi.py
@@ -179,7 +179,8 @@ def get_vm_info(vm):
     vm_snap = vm.snapshot
 
     vm_name = vm_sum.config.name.replace(" ", "_").lower()
-
+    vm_vm_name = vm_sum.config.name
+    
     # If a VM configuration is in INVALID state, return Inalid status
     if vm_conf == "red":
         vm_data = {

--- a/custom_components/esxi_stats/esxi.py
+++ b/custom_components/esxi_stats/esxi.py
@@ -263,6 +263,7 @@ def get_vm_info(vm):
 
     vm_data = {
         "name": vm_name,
+        "vm_name": vm_vm_name,
         "status": vm_sum.overallStatus,
         "state": vm_state,
         "uptime_hours": vm_uptime,


### PR DESCRIPTION
Added additional attributes: VM's proper name (for calling esxi_stats.vm_power),
and the host name of the VMware host it is running on (enables searching for running VMs by host, allowing to shutdown the VMs prior to shutting down a host server by IMC or PDU).