### PR TITLE
feat: add configurable forced host power actions and harden reboot-time option/stat handling

### DIFF
--- a/custom_components/esxi_stats/button.py
+++ b/custom_components/esxi_stats/button.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from homeassistant.components.button import ButtonEntity
 
 from .const import (
+    CONF_FORCE_HOST_REBOOT,
     DOMAIN,
     DOMAIN_DATA,
     DEFAULT_NAME,
@@ -141,7 +142,7 @@ class ESXiHostRebootButton(ButtonEntity):
                 target_host,
                 "reboot",
                 conn_details,
-                False,  # force=False - user should manually set maintenance mode first
+                self._config_entry.options.get(CONF_FORCE_HOST_REBOOT, False),
                 True    # notify
             )
 

--- a/custom_components/esxi_stats/config_flow.py
+++ b/custom_components/esxi_stats/config_flow.py
@@ -25,6 +25,17 @@ from .esxi import esx_connect, esx_disconnect
 _LOGGER = logging.getLogger(__name__)
 
 
+def _as_bool(value, default=False):
+    """Convert legacy option values into booleans."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    if value is None:
+        return default
+    return bool(value)
+
+
 @config_entries.HANDLERS.register(DOMAIN)
 class ESXiStatsFlowHandler(config_entries.ConfigFlow):
     """Config flow for ESXi Stats."""
@@ -184,18 +195,27 @@ class ESXiStatsOptionsFlow(config_entries.OptionsFlow):
                     ): vol.In(LICENSE_STATES),
                     vol.Optional(
                         CONF_NOTIFY,
-                        default=self.config_entry.options.get(CONF_NOTIFY, True),
+                        default=_as_bool(
+                            self.config_entry.options.get(CONF_NOTIFY, True),
+                            True,
+                        ),
                     ): bool,
                     vol.Optional(
                         CONF_FORCE_HOST_POWER_OFF,
-                        default=self.config_entry.options.get(
-                            CONF_FORCE_HOST_POWER_OFF, False
+                        default=_as_bool(
+                            self.config_entry.options.get(
+                                CONF_FORCE_HOST_POWER_OFF, False
+                            ),
+                            False,
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_FORCE_HOST_REBOOT,
-                        default=self.config_entry.options.get(
-                            CONF_FORCE_HOST_REBOOT, False
+                        default=_as_bool(
+                            self.config_entry.options.get(
+                                CONF_FORCE_HOST_REBOOT, False
+                            ),
+                            False,
                         ),
                     ): bool,
                 }

--- a/custom_components/esxi_stats/config_flow.py
+++ b/custom_components/esxi_stats/config_flow.py
@@ -8,6 +8,8 @@ from homeassistant.core import callback
 
 from .const import (
     CONF_DS_STATE,
+    CONF_FORCE_HOST_POWER_OFF,
+    CONF_FORCE_HOST_REBOOT,
     CONF_LIC_STATE,
     CONF_NOTIFY,
     DOMAIN,
@@ -183,6 +185,18 @@ class ESXiStatsOptionsFlow(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_NOTIFY,
                         default=self.config_entry.options.get(CONF_NOTIFY, True),
+                    ): bool,
+                    vol.Optional(
+                        CONF_FORCE_HOST_POWER_OFF,
+                        default=self.config_entry.options.get(
+                            CONF_FORCE_HOST_POWER_OFF, False
+                        ),
+                    ): bool,
+                    vol.Optional(
+                        CONF_FORCE_HOST_REBOOT,
+                        default=self.config_entry.options.get(
+                            CONF_FORCE_HOST_REBOOT, False
+                        ),
                     ): bool,
                 }
             ),

--- a/custom_components/esxi_stats/const.py
+++ b/custom_components/esxi_stats/const.py
@@ -32,6 +32,8 @@ CONF_NAME = "name"
 CONF_DS_STATE = "datastore"
 CONF_LIC_STATE = "license"
 CONF_NOTIFY = "notify"
+CONF_FORCE_HOST_POWER_OFF = "force_host_power_off"
+CONF_FORCE_HOST_REBOOT = "force_host_reboot"
 
 DEFAULT_NAME = "ESXi"
 DEFAULT_PORT = 443
@@ -42,6 +44,8 @@ DEFAULT_OPTIONS = {
     "datastore": "free_space_gb",
     "license": "status",
     "notify": "true",
+    "force_host_power_off": False,
+    "force_host_reboot": False,
 }
 
 DATASTORE_STATES = [

--- a/custom_components/esxi_stats/const.py
+++ b/custom_components/esxi_stats/const.py
@@ -43,7 +43,7 @@ DEFAULT_LIC_STATE = "status"
 DEFAULT_OPTIONS = {
     "datastore": "free_space_gb",
     "license": "status",
-    "notify": "true",
+    "notify": True,
     "force_host_power_off": False,
     "force_host_reboot": False,
 }

--- a/custom_components/esxi_stats/esxi.py
+++ b/custom_components/esxi_stats/esxi.py
@@ -247,6 +247,18 @@ def get_cpu_fan_speed(host, host_name):
 
 def get_host_info(host):
     """Get host information."""
+    def _safe_div_round(value, divisor, digits):
+        """Return rounded division result or n/a for missing values."""
+        if value is None or divisor in (None, 0):
+            return "n/a"
+        return round(value / divisor, digits)
+
+    def _safe_mul_div_round(value_a, value_b, divisor, digits):
+        """Return rounded multiply/divide result or n/a for missing values."""
+        if value_a is None or value_b is None or divisor in (None, 0):
+            return "n/a"
+        return round((value_a * value_b) / divisor, digits)
+
     host_summary = host.summary
     host_state = host_summary.runtime.powerState
     host_name = host_summary.config.name.replace(" ", "_").lower()
@@ -262,13 +274,16 @@ def get_host_info(host):
     if host_state == "poweredOn":
         host_version = host_summary.config.product.version
         host_build = host_summary.config.product.build
-        host_uptime = round(host_summary.quickStats.uptime / 3600, 1)
-        host_cpu_total = round(
-            host_summary.hardware.cpuMhz * host_summary.hardware.numCpuCores / 1000, 1
+        host_uptime = _safe_div_round(host_summary.quickStats.uptime, 3600, 1)
+        host_cpu_total = _safe_mul_div_round(
+            host_summary.hardware.cpuMhz,
+            host_summary.hardware.numCpuCores,
+            1000,
+            1,
         )
-        host_mem_total = round(host_summary.hardware.memorySize / 1073741824, 2)
-        host_cpu_usage = round(host_summary.quickStats.overallCpuUsage / 1000, 1)
-        host_mem_usage = round(host_summary.quickStats.overallMemoryUsage / 1024, 2)
+        host_mem_total = _safe_div_round(host_summary.hardware.memorySize, 1073741824, 2)
+        host_cpu_usage = _safe_div_round(host_summary.quickStats.overallCpuUsage, 1000, 1)
+        host_mem_usage = _safe_div_round(host_summary.quickStats.overallMemoryUsage, 1024, 2)
 
         # Get current power policy
         try:

--- a/custom_components/esxi_stats/switch.py
+++ b/custom_components/esxi_stats/switch.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from homeassistant.components.switch import SwitchEntity
 
 from .const import (
+    CONF_FORCE_HOST_POWER_OFF,
     DOMAIN,
     DOMAIN_DATA,
     DEFAULT_NAME,
@@ -315,7 +316,7 @@ class ESXiHostSwitch(SwitchEntity):
                 target_host,
                 "shutdown",
                 conn_details,
-                False,  # force=False - user should manually set maintenance mode first
+                self._config_entry.options.get(CONF_FORCE_HOST_POWER_OFF, False),
                 True    # notify
             )
 

--- a/custom_components/esxi_stats/translations/el.json
+++ b/custom_components/esxi_stats/translations/el.json
@@ -33,7 +33,9 @@
                 "data": {
                     "datastore": "Χαρακτηριστικό Κατάστασης Datastore",
                     "license": "Χαρακτηριστικό Κατάστασης Αδειών",
-                    "notify": "Δημιουργία service call ειδοποιήσεων"
+                    "notify": "Δημιουργία service call ειδοποιήσεων",
+                    "force_host_power_off": "Εξαναγκασμός τερματισμού λειτουργίας host",
+                    "force_host_reboot": "Εξαναγκασμός επανεκκίνησης host"
                 },
                 "description": "Ρυθμίστε χαρακτηριστικά κατάστασης για αισθητήρες datastore και αδειών."
             }

--- a/custom_components/esxi_stats/translations/en.json
+++ b/custom_components/esxi_stats/translations/en.json
@@ -33,7 +33,9 @@
                 "data": {
                     "datastore": "Datastore State Attribute",
                     "license": "License State Attribute",
-                    "notify": "Create service call notifications"
+                    "notify": "Create service call notifications",
+                    "force_host_power_off": "Force host power off",
+                    "force_host_reboot": "Force host reboot"
                 },
                 "description": "Configure state attributes for datastore and license sensors. Changing options will force integration reload."
             }

--- a/custom_components/esxi_stats/translations/fr.json
+++ b/custom_components/esxi_stats/translations/fr.json
@@ -32,7 +32,9 @@
                 "data": {
                     "datastore": "Attributs d'état du datastore",
                     "license": "Attributs d'état de la licence",
-                    "notify": "Créer des notifications d'appel de service"
+                    "notify": "Créer des notifications d'appel de service",
+                    "force_host_power_off": "Forcer l'arrêt de l'hôte",
+                    "force_host_reboot": "Forcer le redémarrage de l'hôte"
                 },
                 "description": "Configurez les attributs d'état pour les capteurs de datastore et de licence."
             }

--- a/custom_components/esxi_stats/translations/no.json
+++ b/custom_components/esxi_stats/translations/no.json
@@ -32,7 +32,9 @@
                 "data": {
                     "datastore": "Attributt for datalagertilstand",
                     "license": "Attributt for lisenstilstand",
-                    "notify": "Lag notifikasjoner for tjenestekall"
+                    "notify": "Lag notifikasjoner for tjenestekall",
+                    "force_host_power_off": "Tving verten til å slå seg av",
+                    "force_host_reboot": "Tving omstart av vert"
                 },
                 "description": "Konfigurer tilstandsattributter for datalager- og lisensensorer."
             }

--- a/custom_components/esxi_stats/translations/zh-Hans.json
+++ b/custom_components/esxi_stats/translations/zh-Hans.json
@@ -32,7 +32,9 @@
                 "data": {
                     "datastore": "数据存储状态属性",
                     "license": "许可证状态属性",
-                    "notify": "创建服务调用通知"
+                    "notify": "创建服务调用通知",
+                    "force_host_power_off": "强制关闭主机电源",
+                    "force_host_reboot": "强制重启主机"
                 },
                 "description": "配置数据存储和许可证传感器的状态属性。"
             }


### PR DESCRIPTION
## Summary
This PR adds configurable force behavior for host power controls and fixes two follow-up stability issues discovered during testing:

1. Adds integration options to force host power actions from UI entities.
2. Fixes `expected bool` when saving options (legacy option type coercion).
3. Prevents transient setup retries during host reboot caused by `None` host metrics (`unsupported operand type(s) for /: 'NoneType' and 'int'`).

## What Changed
- Added two new options (default `false`):
  - `force_host_power_off`
  - `force_host_reboot`
- Wired host UI controls to respect those options:
  - Host switch shutdown path uses `force_host_power_off`
  - Host reboot button path uses `force_host_reboot`
- Updated options schema handling:
  - Normalizes legacy string values (e.g. `"true"`, `"false"`) to booleans
  - Corrected `notify` default type to boolean
- Added/updated translation keys for all existing locales:
  - `en`, `el`, `fr`, `no`, `zh-Hans`
- Hardened host metric calculations during reboot:
  - Guard division/multiplication math against `None` and zero divisors
  - Return `"n/a"` instead of raising runtime exceptions while host stats are temporarily unavailable

## User Impact
- Users can choose whether host reboot/shutdown actions should pass `force: true` from integration options.
- Saving options no longer fails with `expected bool`.
- Integration remains stable during host reboot windows, avoiding noisy setup retry errors.

## Validation Performed
- Verified options can be toggled and saved after normalization fix.
- Verified forced host reboot path executes successfully and triggers host reboot.
- Verified reboot-time host stats no longer raise `NoneType/int` math exceptions; missing values are reported as `"n/a"` until metrics recover.
- Confirmed forced host shutdown path executes successfully.

## Related
- Addresses upstream request/approach discussed in issue #123.